### PR TITLE
Fix: GitHub Actions permissions for FTP deployment

### DIFF
--- a/.github/workflows/deploy-ftp.yml
+++ b/.github/workflows/deploy-ftp.yml
@@ -14,6 +14,11 @@ jobs:
     
     runs-on: ubuntu-latest
     
+    permissions:
+      contents: read
+      pull-requests: write
+      issues: write
+    
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/GITHUB_ACTIONS_SETUP.md
+++ b/GITHUB_ACTIONS_SETUP.md
@@ -25,7 +25,7 @@ The repository includes a GitHub Actions workflow:
 | `FTP_HOST` | `server298.com` | Your FTP server hostname |
 | `FTP_USER` | `dew_ftp` | Your FTP username |
 | `FTP_PASSWORD` | `[your password]` | Your FTP password |
-| `FTP_REMOTE_DIR` | `www/www-2025` | Remote directory path |
+| `FTP_REMOTE_DIR` | `/www/www-2025/` | Remote directory path (must end with /) |
 
 ### Step 2: Test the Workflow
 


### PR DESCRIPTION
## Fixes GitHub Actions Workflow

This PR fixes two issues discovered during testing:

### Issues Fixed
1. **Permissions Error**: Added permissions block to allow the workflow to post comments to PRs
   - Fixes: `Resource not accessible by integration` error
   
2. **Documentation Update**: Clarified that FTP_REMOTE_DIR must end with /
   - The secret should be: `/www/www-2025/`

### Changes
- Added `permissions` block to workflow with:
  - `contents: read`
  - `pull-requests: write` 
  - `issues: write`
- Updated GITHUB_ACTIONS_SETUP.md documentation

### Testing
When this PR is merged, the workflow should:
- ✅ Successfully deploy to FTP
- ✅ Post a comment back to the PR with deployment status

🤖 Generated with Claude Code